### PR TITLE
correct table for m_vecVelocity

### DIFF
--- a/entities/baseentity.js
+++ b/entities/baseentity.js
@@ -93,7 +93,7 @@ class BaseEntity {
    * @returns {object} {x, y, z} speed in each axis
    */
   get velocity() {
-    return this.getProp('DT_BaseEntity', 'm_vecVelocity');
+    return this.getProp('DT_LocalPlayerExclusive', 'm_vecVelocity');
   }
 
   /**


### PR DESCRIPTION
hey 

I was playing with velocity and randomly noticed slight error in your recent patch. You used wrong table to extract player's velocity, here is a solution

thanks for the lib