### PR TITLE
add mp5-sd definition

### DIFF
--- a/entities/weapon.js
+++ b/entities/weapon.js
@@ -59,6 +59,10 @@ var itemDefinitionIndexMap = {
     itemName: 'P90',
     className: 'weapon_p90',
   },
+  23: {
+    itemName: 'MP5-SD',
+    className: 'weapon_mp5sd'
+  },	       
   24: {
     itemName: 'UMP-45',
     className: 'weapon_ump45',


### PR DESCRIPTION
Adds the definition of the newly added MP5-SD to weapon.js in order to set the correct class-name for the MP5. The m_iItemDefinitionIndex for the MP5-SD is `23` and the correct class-name is `weapon_mp5sd`.