### PR TITLE
Remove error re-throw during parsing

### DIFF
--- a/dist/demo.js
+++ b/dist/demo.js
@@ -4,6 +4,7 @@ const events_1 = require("events");
 const timers = require("timers");
 const ByteBuffer = require("bytebuffer");
 const bitbuffer_1 = require("./ext/bitbuffer");
+const process = require("process");
 const assert = require("assert");
 const consts_1 = require("./consts");
 const convars_1 = require("./convars");
@@ -249,12 +250,7 @@ class DemoFile extends events_1.EventEmitter {
             this.cancel();
             this.emit("tickend", this.currentTick);
             this.emit("end", { error: e });
-            // See GH #11: A sizeable proportion of demo files aren't complete.
-            // If we hit a RangeError, just silently swallow it (as the official
-            // game client does)
-            if (!(e instanceof RangeError)) {
-                throw e;
-            }
+            process.emitWarning(e);
         }
     }
 }

--- a/dist/demo.js
+++ b/dist/demo.js
@@ -250,7 +250,12 @@ class DemoFile extends events_1.EventEmitter {
             this.cancel();
             this.emit("tickend", this.currentTick);
             this.emit("end", { error: e });
-            process.emitWarning(e);
+            // See GH #11: A sizeable proportion of demo files aren't complete.
+            // If we hit a RangeError, just silently swallow it (as the official
+            // game client does)
+            if (!(e instanceof RangeError)) {
+                process.emitWarning(e);
+            }
         }
     }
 }

--- a/src/demo.ts
+++ b/src/demo.ts
@@ -4,6 +4,7 @@ import * as timers from "timers";
 import * as ByteBuffer from "bytebuffer";
 import { BitStream } from "./ext/bitbuffer";
 
+import process = require("process");
 import assert = require("assert");
 import { MAX_OSPATH } from "./consts";
 import { ConVars } from "./convars";
@@ -611,6 +612,8 @@ export class DemoFile extends EventEmitter {
 
       this.emit("tickend", this.currentTick);
       this.emit("end", { error: e });
+
+      process.emitWarning(e);
     }
   }
 }

--- a/src/demo.ts
+++ b/src/demo.ts
@@ -613,7 +613,12 @@ export class DemoFile extends EventEmitter {
       this.emit("tickend", this.currentTick);
       this.emit("end", { error: e });
 
-      process.emitWarning(e);
+      // See GH #11: A sizeable proportion of demo files aren't complete.
+      // If we hit a RangeError, just silently swallow it (as the official
+      // game client does)
+      if (!(e instanceof RangeError)) {
+          process.emitWarning(e);
+      }
     }
   }
 }

--- a/src/demo.ts
+++ b/src/demo.ts
@@ -611,13 +611,6 @@ export class DemoFile extends EventEmitter {
 
       this.emit("tickend", this.currentTick);
       this.emit("end", { error: e });
-
-      // See GH #11: A sizeable proportion of demo files aren't complete.
-      // If we hit a RangeError, just silently swallow it (as the official
-      // game client does)
-      if (!(e instanceof RangeError)) {
-        throw e;
-      }
     }
   }
 }


### PR DESCRIPTION
Fixes #96.

All exceptions are passed to the client code via emitting 'end' event. 
There is no particular need to re-throw an error. Especially because it's impossible to handle re-thrown error properly as described in #96.

Please let me know what do you think.

Thank you,
Alexey