### PR TITLE
feat: generate ts definitions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3721,6 +3721,12 @@
           "resolved": "https://registry.npmjs.org/marked/-/marked-0.4.0.tgz",
           "integrity": "sha512-tMsdNBgOsrUophCAFQl0XPe6Zqk/uy9gnue+jIIKhykO51hxyu6uNx7zBPy0+y/WKYVZZMspV9YeXLNdKk+iYw==",
           "dev": true
+        },
+        "typescript": {
+          "version": "3.1.6",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.6.tgz",
+          "integrity": "sha512-tDMYfVtvpb96msS1lDX9MEdHrW4yOuZ4Kdc4Him9oU796XldPYF/t2+uKoX0BBa0hXXwDlqYQbXY5Rzjzc5hBA==",
+          "dev": true
         }
       }
     },
@@ -3731,9 +3737,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.1.tgz",
-      "integrity": "sha512-Veu0w4dTc/9wlWNf2jeRInNodKlcdLgemvPsrNpfu5Pq39sgfFjvIIgTsvUHCoLBnMhPoUA+tFxsXjU6VexVRQ==",
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.2.tgz",
+      "integrity": "sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==",
       "dev": true
     },
     "typestrict": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "lint": "tslint -p . --fix --exclude 'src/**/*.d.ts'",
-    "build": "tsc",
+    "build": "tsc && cp src/protobufs/*.d.ts dist/protobufs",
     "watch": "tsc -w",
     "generate-docs": "shx rm -rf docs && typedoc --out docs/ && shx touch docs/.nojekyll",
     "bundle": "npm run build && browserify browser/app.js -d -o browser/bundle.js",
@@ -48,7 +48,7 @@
     "tslint-config-prettier": "^1.15.0",
     "tslint-language-service-ts3": "^1.0.0",
     "typedoc": "^0.13.0",
-    "typescript": "^3.1.1",
+    "typescript": "3.7.2",
     "typestrict": "^1.0.1"
   },
   "husky": {

--- a/src/entities.ts
+++ b/src/entities.ts
@@ -503,7 +503,7 @@ export class Entities extends EventEmitter {
 
       if (prop.type === PropType.DataTable) {
         const subTable = assertExists(this._findTableByName(prop.dtName));
-        excludes.push.apply(excludes, this._gatherExcludes(subTable));
+        excludes.push(...this._gatherExcludes(subTable));
       }
     }
 
@@ -537,7 +537,7 @@ export class Entities extends EventEmitter {
           }
         }
 
-        flattened.push.apply(flattened, childProps);
+        flattened.push(...childProps);
       } else {
         flattened.push({
           prop,

--- a/src/entities/team.ts
+++ b/src/entities/team.ts
@@ -4,7 +4,7 @@ import { Player } from "./player";
 
 export type TeamName = "SPECTATOR" | "TERRORIST" | "COUNTERTERRORIST";
 
-export const enum TeamNumber {
+export enum TeamNumber {
   Unassigned = 0,
   Spectator = 1,
   Terrorists = 2,

--- a/src/examples/dumpfile.ts
+++ b/src/examples/dumpfile.ts
@@ -138,7 +138,7 @@ function parseDemoFile(path: string) {
         )
         .filter(s => s.length);
 
-      const formatted = util.format.apply(null, params);
+      const formatted = util.format(params);
       console.log(formatSayText(0, formatted));
     });
 
@@ -150,7 +150,7 @@ function parseDemoFile(path: string) {
       const nonEmptyParams = e.params.filter(s => s.length);
       const msgText = standardMessages[e.msgName];
       const formatted = msgText
-        ? util.format.apply(null, [msgText].concat(nonEmptyParams))
+        ? util.format([msgText].concat(nonEmptyParams))
         : `${e.msgName} ${nonEmptyParams.join(" ")}`;
 
       console.log(formatSayText(e.entIdx, formatted));

--- a/src/generators/itemdefs.ts
+++ b/src/generators/itemdefs.ts
@@ -24,7 +24,7 @@ async function parseItems(root: string) {
   const { lang } = parse(englishData);
   const tokens = new Map(
     Object.entries(lang.Tokens).map(
-      ([token, value]: [string, {}]): [string, string] => [
+      ([token, value]: [string, unknown]): [string, string] => [
         token.toLowerCase(),
         value as string
       ]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,8 @@
     "strict": true,
     "outDir": "./dist",
     "allowJs": true,
+    "declaration": true,
+    "skipLibCheck": true,
     "target": "es2017",
     "lib": ["es2017"],
     "module": "commonjs",
@@ -19,5 +21,5 @@
     "sourceMap": true
   },
   "compileOnSave": true,
-  "include": ["./src/**/*.ts", "./src/protobufs/*.js"]
+  "include": ["./src/**/*.ts"]
 }


### PR DESCRIPTION
Hi!

Since TS 3.7 we can now generate definition files even if the compiler option `allowJS` is enabled.
It makes it easier to generate internal definitions of demofile.

This PR includes the TS 3.7 upgrade and config adjustments to generate definitions.

Notes:
-  As the main entry point doesn't export *all types*, you may have to import it explicitly, i.e.  `import { TeamNumber } from 'demofile/dist/entities/team'` vs `import { Player } from 'demofile'` (`Player` is exported from the main file)
- As protobuf js files are now excluded, the docs don't include it 
[this doc for example](https://saul.github.io/demofile/modules/_protobufs_cstrike15_usermessages_.html)
- PR doesn't include dist files generated by npm scripts to avoid noise, let me know if you want dist files as part of the PR.

It should fix https://github.com/saul/demofile/issues/115

Thank you