### PR TITLE
feat: decode varints 32

### DIFF
--- a/src/props.ts
+++ b/src/props.ts
@@ -93,13 +93,11 @@ function makeIntDecoder(
   sendProp: ISendProp
 ): (bitbuf: BitStream) => number | EntityHandle | boolean {
   if ((sendProp.flags & SPROP_VARINT) !== 0) {
-    /*eslint-disable no-unreachable*/
     if ((sendProp.flags & SPROP_UNSIGNED) !== 0) {
-      throw new Error("32-bit unsigned varints not implemented"); // TODO
+      return bitbuf => bitbuf.readUVarInt32();
     } else {
-      throw new Error("32-bit signed varints not implemented"); // TODO
+      return bitbuf => bitbuf.readVarInt32();
     }
-    /*eslint-enable no-unreachable*/
   } else {
     const numBits = sendProp.numBits;
     if ((sendProp.flags & SPROP_UNSIGNED) !== 0) {


### PR DESCRIPTION
Hi! This PR adds decoding of VarInt32 used in old demos.

Example demo from 2015: https://www39.zippyshare.com/v/XgBgJn05/file.html

Running `dumpfile.js` with this demo will throw an error not related to this PR.
The error comes from the fact that `userInfo` in the `Player` entity may be `null` but we try to access it to get for example the player's name.
I will open another PR to remove the `!` operator used in some `Player` getter.

This script can be used to test it with the demo linked above:
```js
import fs = require("fs");
import demo = require("../demo");
import { TeamNumber } from "../entities/team";
import { Player } from "../entities/player";

function parseDemoFile(path: string) {
  fs.readFile(path, (err, buffer) => {
    const demoFile = new demo.DemoFile();

    demoFile.gameEvents.on("round_officially_ended", e => {
      demoFile.players.forEach(player => {
        console.log(player.name);
      });
      const teams = demoFile.teams;

      const terrorists = teams[TeamNumber.Terrorists];
      const cts = teams[TeamNumber.CounterTerrorists];

      console.log(
        terrorists.teamName,
        terrorists.clanName,
        terrorists.score,
        cts.teamName,
        cts.clanName,
        cts.score
      );
    });

    demoFile.parse(buffer);
  });
}
parseDemoFile(process.argv[2]);
```

Thank you


