### PR TITLE
fix: return only valid players in team members getter

### DIFF
--- a/src/entities/team.ts
+++ b/src/entities/team.ts
@@ -20,9 +20,9 @@ export class Team extends Networkable<CTeam> {
    */
   get members(): Player[] {
     // UNSAFE: cast here as members will always be players
-    return (this.getProp("DT_Team", '"player_array"').map(
-      index => this._demo.entities.entities[index]
-    ) as unknown) as Player[];
+    return this.getProp("DT_Team", '"player_array"')
+      .map(index => this._demo.entities.entities[index] as unknown)
+      .filter(player => player instanceof Player) as Player[];
   }
 
   /**


### PR DESCRIPTION
Hi,

This PR ensures that only valid players are returned by the `members` getter. 
I noticed that It may contain null values, let me know if you want a demo to reproduce it.

Thank you