### PR TITLE
chore(package): reduce package size

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,10 @@
     "version": "npm run generate-docs && git add -A docs",
     "postversion": "git push && git push --tags && npm publish"
   },
+  "files": [
+    "dist",
+    "browser"
+  ],
   "main": "dist/demo.js",
   "dependencies": {
     "bit-buffer": "0.0.3",


### PR DESCRIPTION
The current package size is 46.3 MB, of which the documentation weighs 26MB. I think it's worth keeping only assembly files.